### PR TITLE
Fix inconsistent planner return order

### DIFF
--- a/controllers/robot_controller/robot_controller.py
+++ b/controllers/robot_controller/robot_controller.py
@@ -28,7 +28,7 @@ while robot.step(timestep) != -1:
     if not cmd:
         continue
 
-    natural_reply, plan = propose_plan(cmd)
+    plan, natural_reply = propose_plan(cmd)
     if plan:
         send_response(f"Proposed Plan: {[(step.function.name, step.function.arguments) for step in plan]}")
     send_response(natural_reply)

--- a/lunarbot/planner.py
+++ b/lunarbot/planner.py
@@ -147,7 +147,8 @@ def propose_plan(user_command: str):
     reply = message.content or ""
     tool_calls = message.tool_calls or []
 
-    return reply, tool_calls
+    # return order should match ``resume_after_tools`` for consistency
+    return tool_calls, reply
 
 def resume_after_tools(tool_outputs: list):
     for output in tool_outputs:


### PR DESCRIPTION
## Summary
- return tool calls before reply in `propose_plan`
- update robot controller to match the new order

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685eae2b3f3883218b38859fce20501c